### PR TITLE
Changed invalid url for gRPC

### DIFF
--- a/_src/faq/index.md
+++ b/_src/faq/index.md
@@ -136,7 +136,7 @@ So, it's likely that you want to encode errors in your response struct.
 ## Which transports are supported?
 
 Go kit ships with support for HTTP,
- [gRPC](https://grpc.io),
+ [gRPC](http://www.grpc.io),
  [Thrift](https://thrift.apache.org), and
  [net/rpc](https://golang.org/pkg/net/rpc/).
 It's straightforward to add support for new transports;


### PR DESCRIPTION
Hi there! 

When I followed [https://grpc.io](https://grpc.io) from the docs there was a name mismatch error [1]. 
It appears the new url is [http://www.grpc.io](http://www.grpc.io) [2].



[1] <img width="997" alt="screen shot 2017-01-21 at 1 30 21 pm" src="https://cloud.githubusercontent.com/assets/3827393/22176684/cd964f56-dfdd-11e6-9b47-3adf6ffa76d6.png">
[2] https://github.com/grpc/