### PR TITLE
Removed ctx from NewServer

### DIFF
--- a/examples/stringsvc.html
+++ b/examples/stringsvc.html
@@ -192,14 +192,12 @@ func main() {
 	svc := stringService{}
 
 	uppercaseHandler := httptransport.NewServer(
-		ctx,
 		makeUppercaseEndpoint(svc),
 		decodeUppercaseRequest,
 		encodeResponse,
 	)
 
 	countHandler := httptransport.NewServer(
-		ctx,
 		makeCountEndpoint(svc),
 		decodeCountRequest,
 		encodeResponse,


### PR DESCRIPTION
Based on [these changes](https://github.com/go-kit/kit/commit/5b4da74163069a1b1763c6a580eba617cd8880d1), `NewServer` no longer requires a `ctx` parameter.