### PR TITLE
stringsvc example: Fix NewServer invocation

### DIFF
--- a/_src/examples/stringsvc.md
+++ b/_src/examples/stringsvc.md
@@ -128,18 +128,15 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
 	svc := stringService{}
 
 	uppercaseHandler := httptransport.NewServer(
-		ctx,
 		makeUppercaseEndpoint(svc),
 		decodeUppercaseRequest,
 		encodeResponse,
 	)
 
 	countHandler := httptransport.NewServer(
-		ctx,
 		makeCountEndpoint(svc),
 		decodeCountRequest,
 		encodeResponse,

--- a/examples/stringsvc.html
+++ b/examples/stringsvc.html
@@ -188,18 +188,15 @@ Go kit provides a helper struct, in package transport/http.</p>
 )
 
 func main() {
-	ctx := context.Background()
 	svc := stringService{}
 
 	uppercaseHandler := httptransport.NewServer(
-		ctx,
 		makeUppercaseEndpoint(svc),
 		decodeUppercaseRequest,
 		encodeResponse,
 	)
 
 	countHandler := httptransport.NewServer(
-		ctx,
 		makeCountEndpoint(svc),
 		decodeCountRequest,
 		encodeResponse,


### PR DESCRIPTION
The NewServer function does not take context.Context as its first
argument anymore. See https://godoc.org/github.com/go-kit/kit/transport/http#NewServer.

Duplicates #3, but fixes the documentation source as well.