### PR TITLE
clarify loggingMiddleware is not yet defined

### DIFF
--- a/_src/examples/stringsvc.md
+++ b/_src/examples/stringsvc.md
@@ -266,6 +266,7 @@ import (
 ```
 
 And wire it into each of our handlers.
+Note that the next code section will *not* compile until you follow the **Application Logging** section, which defines loggingMiddleware.
 
 ```go
 logger := log.NewLogfmtLogger(os.Stderr)


### PR DESCRIPTION
While following the tutorial (and thanks a lot for it), on the Transport Logging section, I got an error that loggingMiddleware is not defined, up to that point I had followed the code snippets and run/test, took me a while to understand the code wasn't ready to be ran. There's an open issue #17 which also pointed this out but the pull request doesn't address this part. Thank you for your awesome work!