### PR TITLE
Fix broken dropwizard link in main page

### DIFF
--- a/_src/index.html
+++ b/_src/index.html
@@ -38,7 +38,7 @@
 <h3>👥&nbsp; Similar to...</h3>
 <p>
 	<a href="https://twitter.github.io/finagle/">Finagle</a> &bull;
-	<a href="http://www.dropwizard.io/0.9.2/docs/">Dropwizard</a> &bull;
+	<a href="https://www.dropwizard.io/en/stable/">Dropwizard</a> &bull;
 	<a href="http://projects.spring.io/spring-boot/">Spring Boot</a> &bull;
 	<a href="https://netflix.github.io/">Netflix</a>
 	 <a href="https://github.com/Netflix/eureka">Eureka</a> ·


### PR DESCRIPTION
Dropwizard link in main page was broken. So I replaced that link to valid one.